### PR TITLE
Add get balance example

### DIFF
--- a/examples/examples/get-balance-example.js
+++ b/examples/examples/get-balance-example.js
@@ -9,8 +9,7 @@ const RPC_URL =
   process.env.RPC_URL ||
   'https://json-rpc.uno.sentry.testnet.v3.kiivalidator.com/';
 const ADDRESS =
-  process.env.ADDRESS ||
-  '0xAB1F600358Acd5A163d9E2C64a8840a267F983F9'; // ✅ Valid checksum
+  process.env.ADDRESS || '0xAB1F600358Acd5A163d9E2C64a8840a267F983F9'; // ✅ Valid checksum
 
 const provider = new ethers.JsonRpcProvider(RPC_URL);
 


### PR DESCRIPTION
This pull request adds an example script to demonstrate how to fetch the balance of a wallet using the ethers.js provider. It uses a default address and RPC URL to keep it simple.

- Added: `examples/get-balance-example.js`
- Shows how to:
  - Load `.env` variables or use defaults
  - Initialize an `ethers` provider
  - Fetch and format balance

This example helps new developers understand how to use the SDK for basic balance queries.

More examples for other SDK features will be added incrementally.
Related to #13