### PR TITLE
[fix] Update pubkey import path and add signer tests

### DIFF
--- a/packages/utils/src/cosmjs/signer.ts
+++ b/packages/utils/src/cosmjs/signer.ts
@@ -10,7 +10,7 @@ import { makeAuthInfoBytes, makeSignDoc } from '@cosmjs/proto-signing';
 
 import { Any } from 'cosmjs-types/google/protobuf/any';
 import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
-import { PubKey } from '@kiichain/kiijs-proto/cosmos/evm/crypto/v1/ethsecp256k1/keys';
+import { PubKey } from '@kiichain/kiijs-proto/src/cosmos/evm/crypto/v1/ethsecp256k1/keys';
 import { BaseAccount } from 'cosmjs-types/cosmos/auth/v1beta1/auth';
 
 // This function signs a transaction using the ethsecp256k1 signer

--- a/packages/utils/tests/signer.test.ts
+++ b/packages/utils/tests/signer.test.ts
@@ -1,0 +1,53 @@
+import { Any } from 'cosmjs-types/google/protobuf/any';
+import { BaseAccount } from 'cosmjs-types/cosmos/auth/v1beta1/auth';
+import { PubKey } from '@kiichain/kiijs-proto/src/cosmos/evm/crypto/v1/ethsecp256k1/keys';
+
+import { ethsecpAccountParser } from '../src/cosmjs/signer';
+import 'dotenv/config';
+
+describe('Ethsecp Signer Tests', () => {
+  // Test for ethsecpAccountParser
+  describe('ethsecpAccountParser', () => {
+    it('should parse BaseAccount with ethsecp256k1 pubkey', () => {
+      // Create a real Any object with BaseAccount typeUrl
+      const pubkeyValue = new Uint8Array([1, 2, 3]);
+      const pubkeyAny = Any.fromPartial({
+        typeUrl: '/cosmos.evm.crypto.v1.ethsecp256k1.PubKey',
+        value: PubKey.encode({
+          key: pubkeyValue,
+        }).finish(),
+      });
+
+      const baseAccount = BaseAccount.fromPartial({
+        address: 'kii1ver6l8fajk8se6w3dyfefx36jzu2gzn2qmu3t9',
+        accountNumber: BigInt(12345),
+        sequence: BigInt(67890),
+        pubKey: pubkeyAny,
+      });
+
+      const accountAny = Any.fromPartial({
+        typeUrl: '/cosmos.auth.v1beta1.BaseAccount',
+        value: BaseAccount.encode(baseAccount).finish(),
+      });
+
+      const result = ethsecpAccountParser(accountAny);
+
+      // Verify the result has the correct structure
+      expect(result).toBeDefined();
+      expect(result.address).toBe(baseAccount.address);
+      expect(result.accountNumber).toBe(baseAccount.accountNumber);
+      expect(result.sequence).toBe(baseAccount.sequence);
+    });
+
+    it('should throw error for unknown account type', () => {
+      const accountAny: Any = {
+        typeUrl: '/unknown.type',
+        value: new Uint8Array([7, 8, 9]),
+      };
+
+      expect(() => ethsecpAccountParser(accountAny)).toThrow(
+        `Unknown account type: ${accountAny.typeUrl}`
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Description

- Updated the import path for `PubKey` in `signer.ts` to use the correct proto source path.
- Added comprehensive unit tests for the `ethsecpAccountParser` function:
  - Verify correct parsing of `BaseAccount` with `ethsecp256k1` pubkey.
  - Verify error handling for unknown account types.

This PR will close issue #29.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] test (For updates on tests)

# How Has This Been Tested?

- Ran `npm run test` with new and existing test cases.
- Verified all test suites passed successfully.

<img width="567" height="306" alt="Screenshot_16" src="https://github.com/user-attachments/assets/4d961153-e552-460b-b909-8d94462ebec7" />

