### PR TITLE
fix[build]: remove quotes from prettier command in build script

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,7 +22,7 @@
 		"build:cjs": "tsc --outDir dist/cjs --module commonjs",
 		"build:esm": "tsc --outDir dist/esm --module esnext",
 		"build:types": "tsc --project ./tsconfig.declaration.json",
-		"build:prettier": "prettier --write 'dist/**/*.js'",
+		"build:prettier": "prettier --write dist/**/*.js",
 		"docs": "typedoc --out docs",
 		"test": "jest",
 		"test:ci": "jest",


### PR DESCRIPTION
# Description

This PR fixes a build failure in the `@kiichain/kiijs-utils` package.  
The issue was caused by quotes around the glob pattern in the `prettier` command,  
which prevented it from matching files correctly on some environments (e.g., Windows). 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Ran `npm build` locally after the fix
- [x] Verified that Prettier executed correctly without errors
- [x] Confirmed that build completed successfully

 
<img width="956" height="646" alt="Screenshot_29" src="https://github.com/user-attachments/assets/e013c1f8-e831-4122-81b6-30632d14c1af" />

## Test Configuration

- OS: Windows 10
- Node: v22+
- Yarn: v1.22.22